### PR TITLE
Implemented LoST Redirect (Iterative) and Proxy (Recursive) Routing

### DIFF
--- a/lost/resolver/cli.py
+++ b/lost/resolver/cli.py
@@ -3,6 +3,8 @@ import click
 from .. import db
 from .. import osm
 from . import LoSTResolver, create_app, resolver
+from flask import Flask, request
+from .handler import handler
 
 
 @click.group(help='LoST resolver')
@@ -49,5 +51,9 @@ def start(port, root_server, frontend, backend, image_dir):
         click.echo('Serving backend APIs')
 
     app = create_app(frontend=frontend, backend=backend, image_dir=image_dir)
+    
+    # Have Post Requests to the Resolver be handled by the handler() function in handler.py 
+    app.add_url_rule('/', 'handler', handler, methods=['POST'])
+
     app.config['db'] = db.pool
     app.run('0.0.0.0', port, debug=True, threaded=True, use_debugger=False)

--- a/lost/resolver/handler.py
+++ b/lost/resolver/handler.py
@@ -1,0 +1,40 @@
+import sys
+import click
+from .. import db
+from .. import osm
+from . import LoSTResolver, create_app, resolver
+from flask import request, Response, Flask
+import requests
+from lxml import etree, objectify
+import os
+
+app = Flask(__name__)
+
+@app.route('/', methods=['POST'])
+def handler():
+    server_url = 'http://localhost:5000'
+    xml_data = request.data
+    headers = {'Content-Type': 'application/lost+xml'}
+    
+    while True:
+        response = requests.post(server_url, data=xml_data, headers=headers)
+        
+        if response.status_code == 200:
+            tree = etree.fromstring(response.content)
+            ns = {'lost2': 'urn:ietf:params:xml:ns:lost2'}
+            redirect_element = tree.xpath('//lost2:redirect', namespaces=ns)
+
+            if redirect_element:
+                server_url = redirect_element[0].get('target')
+                print(f"Redirect found, redirected to {server_url}")
+            else:
+                print("Leaf node.")
+                break
+        else:
+            print(f"Error: Received status code {response.status_code}")
+            break
+
+    return Response(response.content, mimetype='application/lost+xml')
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/lost/server.py
+++ b/lost/server.py
@@ -20,6 +20,7 @@ from .osm import extract_boundary
 from . import osm
 from .guid import GUID
 import json
+import requests
 
 
 # Instances of LoST servers for various coodinate systems, e.g., geodetic-2d and
@@ -85,6 +86,7 @@ class GeographicLoSTServer(LoSTServer):
 
     def check_authority(self, req: lxml.objectify.ObjectifiedElement):
         pass
+    
 
     # def check_authority(self, req: lxml.objectify.ObjectifiedElement):
     #     with self.db.connection() as con:
@@ -156,7 +158,7 @@ class GeographicLoSTServer(LoSTServer):
         if geom.tag != f'{{{GML_NAMESPACE}}}Point':
             raise GeometryNotImplemented(f'Unsupported geometry type {geom.tag}')
 
-        lat, lon = (geom.pos.text or '').strip().split()    
+        lat, lon = (geom.pos.text or '').strip().split()
         p = f'Point({lon} {lat})'
         with self.db.connection() as con:
             cur = con.execute('''
@@ -167,31 +169,74 @@ class GeographicLoSTServer(LoSTServer):
                 (p, service))
 
             row = cur.fetchone()
+        
+        # Row will be None if no rows are returned, meaning there is no 'lost' service in the mapping table.
+        if row:
+            attrs = row[3]
+            # Not a leaf server and in redirect mode, so send redirect response
+            if self.redirect:
+                redirect_res = Element(f'{{{LOST_NAMESPACE}}}redirect', nsmap=NAMESPACE_MAP)
+                redirect_res.set('target', attrs['uri'])
+                redirect_res.set('source', self.server_id)
+                redirect_res.set('message', 'Redirecting to the next more specific server.')
+                return redirect_res
 
-        if row is None:
-            raise NotFound('No suitable mapping found')
+            # Not a leaf server in proxy mode
+            else:
+                print("proxy")
+                next_server = attrs['uri']
+                return self.proxy_request(next_server, req)
 
-        id, service, updated, attrs, shape = row
+        elif row is None:
+            # It is a leaf server, construct and return the findServiceResponse response
+            with self.db.connection() as con:
+                cur = con.execute('''
+                    SELECT m.id, m.srv, m.updated, m.attrs, ST_AsGML(3, s.geometries, 5, 17) AS shape
+                    FROM   server.mapping AS m JOIN shape AS s ON m.shape=s.id
+                    WHERE  ST_Contains(s.geometries, ST_GeomFromText(%s, 4326))''',
+                    (p,))
 
-        res = Element(f'{{{LOST_NAMESPACE}}}findServiceResponse', nsmap=NAMESPACE_MAP)
-        mapping = SubElement(res, 'mapping',
-            source=self.server_id,
-            sourceId=str(id),
-            lastUpdated=updated.isoformat(),
-            expires=(datetime.now() + timedelta(days=1)).isoformat())
+            row = cur.fetchone()
+            
+            if row is None:
+                # No suitable mapping found, return an error
+                error_res = Element(f'{{{LOST_NAMESPACE}}}error', nsmap=NAMESPACE_MAP)
+                error_res.set('message', 'No suitable mapping found.')
+                return error_res
 
-        if 'displayName' in attrs:
-            dn = SubElement(mapping, 'displayName')
-            dn.set(f'{{{XML_NAMESPACE}}}lang', 'en')
-            dn.text = attrs['displayName']
+            attrs = row[3]
+            res = Element(f'{{{LOST_NAMESPACE}}}findServiceResponse', nsmap=NAMESPACE_MAP)
+            mapping = SubElement(res, 'mapping', source=self.server_id, sourceId=str(row[0]), lastUpdated=row[2].isoformat(), expires=(datetime.now() + timedelta(days=1)).isoformat())
 
-        SubElement(mapping, 'service').text = service
-        mapping.append(serviceBoundary(shape))
+            if 'displayName' in attrs:
+                dn = SubElement(mapping, 'displayName')
+                dn.set(f'{{{XML_NAMESPACE}}}lang', 'en')
+                dn.text = attrs['displayName']
 
-        for uri in attrs.get('uri', []):
-            SubElement(mapping, 'uri').text = uri
+            SubElement(mapping, 'service').text = row[1]
+            mapping.append(serviceBoundary(row[4]))
 
-        return res
+            if 'uri' in attrs:
+                for uri in attrs['uri']:
+                    SubElement(mapping, 'uri').text = uri
+            return res
+
+
+    def proxy_request(self, server_uri, original_request):
+        headers = {'Content-Type': 'application/lost+xml'}
+        try:
+            request_data = lxml.etree.tostring(original_request, pretty_print=True).decode()
+            response = requests.post(server_uri, data=request_data, headers=headers)
+            
+            if response.status_code == 200:
+                response_xml = lxml.etree.fromstring(response.content)
+                response_obj = lxml.objectify.fromstring(lxml.etree.tostring(response_xml))
+                return response_obj
+
+        except Exception as e:
+            error_res = Element(f'{{{LOST_NAMESPACE}}}error', nsmap=NAMESPACE_MAP)
+            error_res.set('message', 'Proxy failed.')
+            return error_res
 
 
 class CivicLoSTServer(LoSTServer):

--- a/lost/server.py
+++ b/lost/server.py
@@ -183,7 +183,6 @@ class GeographicLoSTServer(LoSTServer):
 
             # Not a leaf server in proxy mode
             else:
-                print("proxy")
                 next_server = attrs['uri']
                 return self.proxy_request(next_server, req)
 


### PR DESCRIPTION
The [LoST RFC](https://www.rfc-editor.org/rfc/rfc5222.txt) defines two methods to handle requests. This pull request implements the iterative and recursive modes as defined in the RFC. 

Redirect mode (enabled with the -r flag when starting the server) will either return a redirect response with the URL of the next downstream server or the necessary findServiceResponse if the server is a leaf server. 

Proxy routing will send the findService request to the next downstream server, and then send the response from the downstream server up the hierarchy. 

Servers can either be run in proxy or redirect mode. The changes support a mix of servers running in proxy or redirect mode. 

These above changes are noted in the server.py file.

The changes in cli.py and handler.py are tools meant to automatically handle the redirect responses from the LoST server in redirect mode. These files also handle proxy mode.

You can send a request with the coordinates for the Statue of Liberty using the command `lost-seeker find-service -- lost -74.044454 40.68918`

Ensure that you have the LoST Resolver service running to handle this request. 